### PR TITLE
Automatically remove the fi and ff ligatures in Meslo font

### DIFF
--- a/scripts/powerline-fontpatcher
+++ b/scripts/powerline-fontpatcher
@@ -104,6 +104,9 @@ class FontPatcher(object):
 
 			target_font.em = target_font_em_original
 
+			target_font[0xfb01].clear()
+			target_font[0xfb02].clear()
+
 			# Generate patched font
 			extension = os.path.splitext(target_font.path)[1]
 			if extension.lower() not in ['.ttf', '.otf']:


### PR DESCRIPTION
Menlo and Meslo both have fi and ff ligatures which cause annoyances
when trying to render something fixed width.  This removes them from the
resulting patched powerline font.
