### PR TITLE
Request for comments/brainstorms: making glyphs look better in gnome-terminal

### DIFF
--- a/fonts/powerline-symbols.sfd
+++ b/fonts/powerline-symbols.sfd
@@ -162,10 +162,10 @@ Flags: HW
 LayerCount: 2
 Fore
 SplineSet
-0 1950 m 1
- 1060 788 l 1
- 0 -375 l 1
- 0 1950 l 1
+0 1700 m 1
+ 1060 675 l 1
+ 0 -365 l 1
+ 0 1700 l 1
 EndSplineSet
 EndChar
 
@@ -176,13 +176,13 @@ Flags: HW
 LayerCount: 2
 Fore
 SplineSet
--57 1812 m 1
- 39 1907 l 1
- 1060 788 l 1
- 39 -331 l 1
- -57 -236 l 1
- 875 788 l 1
- -57 1812 l 1
+-57 1600 m 1
+ 39 1700 l 1
+ 1060 675 l 1
+ 39 -365 l 1
+ -57 -265 l 1
+ 875 675 l 1
+ -57 1600 l 1
 EndSplineSet
 EndChar
 
@@ -193,10 +193,10 @@ Flags: HW
 LayerCount: 2
 Fore
 SplineSet
-1060 -375 m 1
- 0 788 l 1
- 1060 1950 l 1
- 1060 -375 l 1
+1060 -365 m 1
+ 0 675 l 1
+ 1060 1700 l 1
+ 1060 -365 l 1
 EndSplineSet
 EndChar
 
@@ -207,13 +207,13 @@ Flags: HW
 LayerCount: 2
 Fore
 SplineSet
-185 788 m 1
- 1117 -236 l 1
- 1021 -331 l 1
- 0 788 l 1
- 1021 1907 l 1
- 1117 1812 l 1
- 185 788 l 1
+185 675 m 1
+ 1117 -265 l 1
+ 1021 -365 l 1
+ 0 675 l 1
+ 1021 1700 l 1
+ 1117 1600 l 1
+ 185 675 l 1
 EndSplineSet
 EndChar
 


### PR DESCRIPTION
These were the changes that I found made the powerline special characters look good in gnome-terminal (Ubuntu Mono 15, Ubuntu-patched rendering libs, Arch Linux). I can already see how fragile this is -- it doesn't look good if I so much as change the font to Deja Vu Mono, much less the OS. (Seems to survive font size changes though.) The command I'm using to generate the symbols TTF file is:

```
fontforge -lang ff -c 'Open($1); Generate($2)' powerline-symbols.sfd powerline-symbols.ttf
```

This isn't appropriate to actually merge, but I'm posting it to get advice. Is FontForge tweaking the way people are expected to get powerline to look good on their platform? Should we think about building a collection of platform-specific patched fonts?

![image](https://cloud.githubusercontent.com/assets/860932/9027422/9dd1009e-3922-11e5-879f-60eb12d9211a.png)
