### PR TITLE
fixes bug #14 replace '/' character from font name with space

### DIFF
--- a/scripts/powerline-fontpatcher
+++ b/scripts/powerline-fontpatcher
@@ -47,6 +47,7 @@ def patch_one_font(source_font, target_font, rename_font=True):
 	if rename_font:
 		target_font.familyname += ' for Powerline'
 		target_font.fullname += ' for Powerline'
+		target_font.fullname = re.sub('/', ' ', target_font.fullname)
 		fontname, style = FONT_NAME_RE.match(target_font.fontname).groups()
 		target_font.fontname = fontname + 'ForPowerline'
 		if style is not None:


### PR DESCRIPTION
This patch will fix the bug #14 which I encountered while patching Anke Coder font. This problem was fontpatcher uses `fullname` to generate filename and anke coder has `/` in it's name, thus fontforge was failing with error.

This patch should fix the problem.

As a note, I used PR  #13 before being able to patch AnkeCoder, because (I believe) it lacks some glyphs. 