### PR TITLE
Fix failure for missing fi ligatures, improve documentation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,42 @@
+**Installation**
+
+First, use your package manager (`brew` if you're using macOS) to install [FontForge](http://fontforge.github.io/en-US/).
+
+Then, clone the repo, build and install:
+
+```bash
+git clone git@github.com:powerline/fontpatcher.git
+cd fontpatcher
+./setup.py build
+./setup.py install
+```
+
+**Usage**:
+
+```
+powerline-fontpatcher [-h] [--no-rename] [--source-font font]
+                             font [font ...]
+
+Font patcher for Powerline. Requires FontForge with Python bindings. Stores
+the patched font as a new, renamed font file by default.
+
+positional arguments:
+  font                font files to patch
+
+optional arguments:
+  -h, --help          show this help message and exit
+  --no-rename         don't add " for Powerline" to the font name
+  --source-font font  source symbol font
+```
+
+**Tip:**
+
+`powerline-fontpatcher` tries to find `powerline-symbold.sfd` in `/usr/share/...` by default. If this fails, then try:
+
+1. Copying the font you'd like to patch into the `fontpatcher` directory.
+
+2. Specifying `--source-font` like so:
+
+`powerline-patcher --source-font ./fonts/powerline-symbols.sfd ./SomeFont.otf`
+
+

--- a/README.rst
+++ b/README.rst
@@ -10,48 +10,8 @@ Powerline and other compatible plugins.**
 
 ------
 
+Check out INSTALL.md for more detailed installation and usage instructions.
+
 Check out `powerline-fonts <https://github.com/Lokaltog/powerline-fonts>`_
 for pre-patched versions of popular, open source coding fonts.
-
-**Installation**
-
-First, use your package manager (`brew` if you're using macOS) to install [FontForge](http://fontforge.github.io/en-US/).
-
-Then, clone the repo, build and install:
-
-```bash
-git clone git@github.com:powerline/fontpatcher.git
-cd fontpatcher
-./setup.py build
-./setup.py install
-```
-
-**Usage**:
-
-```
-powerline-fontpatcher [-h] [--no-rename] [--source-font font]
-                             font [font ...]
-
-Font patcher for Powerline. Requires FontForge with Python bindings. Stores
-the patched font as a new, renamed font file by default.
-
-positional arguments:
-  font                font files to patch
-
-optional arguments:
-  -h, --help          show this help message and exit
-  --no-rename         don't add " for Powerline" to the font name
-  --source-font font  source symbol font
-```
-
-**Tip:**
-
-`powerline-fontpatcher` tries to find `powerline-symbold.sfd` in `/usr/share/...` by default. If this fails, then try:
-
-1. Copying the font you'd like to patch into the `fontpatcher` directory.
-
-2. Specifying `--source-font` like so:
-
-`powerline-patcher --source-font ./fonts/powerline-symbols.sfd ./SomeFont.otf`
-
 

--- a/README.rst
+++ b/README.rst
@@ -5,10 +5,53 @@ Powerline font patcher
 :Source: https://github.com/Lokaltog/powerline-fontpatcher
 :Version: beta
 
-**Script to patch arrow and symbol glyphs into fonts for usage with 
+**Script to patch arrow and symbol glyphs into fonts for usage with
 Powerline and other compatible plugins.**
 
 ------
 
-Check out `powerline-fonts <https://github.com/Lokaltog/powerline-fonts>`_ 
+Check out `powerline-fonts <https://github.com/Lokaltog/powerline-fonts>`_
 for pre-patched versions of popular, open source coding fonts.
+
+**Installation**
+
+First, use your package manager (`brew` if you're using macOS) to install [FontForge](http://fontforge.github.io/en-US/).
+
+Then, clone the repo, build and install:
+
+```bash
+git clone git@github.com:powerline/fontpatcher.git
+cd fontpatcher
+./setup.py build
+./setup.py install
+```
+
+**Usage**:
+
+```
+powerline-fontpatcher [-h] [--no-rename] [--source-font font]
+                             font [font ...]
+
+Font patcher for Powerline. Requires FontForge with Python bindings. Stores
+the patched font as a new, renamed font file by default.
+
+positional arguments:
+  font                font files to patch
+
+optional arguments:
+  -h, --help          show this help message and exit
+  --no-rename         don't add " for Powerline" to the font name
+  --source-font font  source symbol font
+```
+
+**Tip:**
+
+`powerline-fontpatcher` tries to find `powerline-symbold.sfd` in `/usr/share/...` by default. If this fails, then try:
+
+1. Copying the font you'd like to patch into the `fontpatcher` directory.
+
+2. Specifying `--source-font` like so:
+
+`powerline-patcher --source-font ./fonts/powerline-symbols.sfd ./SomeFont.otf`
+
+

--- a/scripts/powerline-fontpatcher
+++ b/scripts/powerline-fontpatcher
@@ -114,8 +114,12 @@ def patch_one_font(source_font, target_font, rename_font=True):
 
 	# FIXME: Menlo and Meslo font do have these substitutes, but U+FB01 and
 	#        U+FB02 still do not show up for fi and fl.
-	target_font[0xFB01].removePosSub('*')  # fi ligature
-	target_font[0xFB02].removePosSub('*')  # fl ligature
+	if 0xFB01 in target_font:
+		target_font[0xFB02].removePosSub('*')  # fl ligature
+	if 0xFB02 in target_font:
+		target_font[0xFB02].removePosSub('*')  # fl ligature
+	# target_font[0xFB01].removePosSub('*')  # fi ligature
+	# target_font[0xFB02].removePosSub('*')  # fl ligature
 
 	# Generate patched font
 	extension = os.path.splitext(target_font.path)[1]


### PR DESCRIPTION
Implemented fix from [powerline/fontpatcher#13](https://github.com/powerline/fontpatcher/pull/13) (prevents Operator Mono from failing)

Added my own installation, usage and troubleshooting notes to a separate INSTALL.md