### PR TITLE
Use system python

### DIFF
--- a/scripts/powerline-fontpatcher
+++ b/scripts/powerline-fontpatcher
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # vim:fileencoding=utf-8:noet
 
 import argparse


### PR DESCRIPTION
Since fontpatcher runs with Python3, too, and some systems use it as default, it would be nice for the script to support Python3.